### PR TITLE
feat: Add TypeScript Type Definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,9 @@
+import type { Plugin } from "unified";
+
+export interface Options {
+	className?: string;
+}
+
+declare const rehypeFigure: Plugin<[Options?]>;
+
+export default rehypeFigure;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
   "repository": "git@github.com:josestg/rehype-figure.git",
   "author": "Jose Alfredo Sitanggang <josealfredositanggang@gmail.com>",
   "license": "MIT",
+  "types": "index.d.ts",
+  "files": [
+    "index.js",
+    "index.d.ts"
+  ],
   "scripts": {
     "test": "nyc --reporter lcov  mocha *.test.js"
   },


### PR DESCRIPTION
Hello! Thank you for creating this useful library.

This pull request introduces TypeScript type definitions (`index.d.ts`).
Currently, TypeScript users get the error when importing this package.
Also, we don't get autocompletions.

<img width="957" alt="image" src="https://github.com/user-attachments/assets/5445759d-f561-4ed8-9294-0781cec27cbc" />

Adding these types will improve the developer experience.

## Change Made

- Added `index.d.ts` with type definitions for main plugin function and its options.
- Update `package.json` to include "types" and "files" fields.

## How to Verify

I have confirmed these type definitions locally in Next.js project.

1. Ran `yarn pack` to create a `.tgz` files.
2. In my test project, I installed the package directly from the local tarball: `npm install `path/to/rehype-figure-1.0.1.tgz`
3. VSCode correctly recognized the types, and `npm run build` completed without any type errors.

## Other

I have not modified the version number in `package.json`